### PR TITLE
Update examples for the latest TinyGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ package main
 
 import "github.com/orsinium-labs/wasm4go/w4"
 
-func main() {
+func init() {
    w4.Update = update
 }
 

--- a/_examples/Taskfile.yml
+++ b/_examples/Taskfile.yml
@@ -4,6 +4,7 @@ version: '3'
 tasks:
   build:
     - test {{.CLI_ARGS}}
+    - tinygo version
     - >
       tinygo build
       -target ./target.json

--- a/_examples/buttons/buttons.go
+++ b/_examples/buttons/buttons.go
@@ -2,7 +2,7 @@ package main
 
 import "github.com/orsinium-labs/wasm4go/w4"
 
-func main() {
+func init() {
 	w4.Update = update
 }
 

--- a/_examples/hello/hello.go
+++ b/_examples/hello/hello.go
@@ -13,7 +13,7 @@ var smiley = []byte{
 	0b11000011,
 }
 
-func main() {
+func init() {
 	w4.Update = update
 }
 

--- a/_examples/palette/palette.go
+++ b/_examples/palette/palette.go
@@ -2,7 +2,7 @@ package main
 
 import "github.com/orsinium-labs/wasm4go/w4"
 
-func main() {
+func init() {
 	w4.Update = update
 }
 

--- a/_examples/snake/snake.go
+++ b/_examples/snake/snake.go
@@ -29,7 +29,7 @@ var (
 	randInt = rand.New(rand.NewSource(1)).Intn
 )
 
-func main() {
+func init() {
 	// Set the function to be called on start.
 	w4.Start = start
 

--- a/_examples/target.json
+++ b/_examples/target.json
@@ -16,6 +16,7 @@
     "--initial-memory=65536",
     "--max-memory=65536",
     "--stack-first",
+    "--no-entry",
     "-zstack-size=14752"
   ]
 }

--- a/_examples/tests/tests.go
+++ b/_examples/tests/tests.go
@@ -2,7 +2,7 @@ package main
 
 import "github.com/orsinium-labs/wasm4go/w4"
 
-func main() {
+func init() {
 	w4.Start = start
 	w4.Update = update
 }


### PR DESCRIPTION
In the current version of TinyGo, the wasm-unknown target doesn't execute the `main` function. Use `init` instead.

Close #3